### PR TITLE
Expose Target class as API 

### DIFF
--- a/spotlight/src/main/java/com/takusemba/spotlight/target/AbstractTargetBuilder.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/target/AbstractTargetBuilder.java
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference;
  * @author takusemba
  * @since 26/06/2017
  **/
-abstract class AbstractTargetBuilder<T extends AbstractTargetBuilder<T, S>, S extends Target> {
+public abstract class AbstractTargetBuilder<T extends AbstractTargetBuilder<T, S>, S extends Target> {
 
     private static final PointF DEFAULT_POINT = new PointF(0, 0);
     private static final long DEFAULT_DURATION = 1000L;
@@ -27,21 +27,21 @@ abstract class AbstractTargetBuilder<T extends AbstractTargetBuilder<T, S>, S ex
     private static final Shape DEFAULT_SHAPE = new Circle(100);
     private WeakReference<Activity> contextWeakReference;
 
-    PointF point = DEFAULT_POINT;
-    Shape shape = DEFAULT_SHAPE;
-    long duration = DEFAULT_DURATION;
-    TimeInterpolator animation = DEFAULT_ANIMATION;
-    OnTargetStateChangedListener listener = null;
+    protected PointF point = DEFAULT_POINT;
+    protected Shape shape = DEFAULT_SHAPE;
+    protected long duration = DEFAULT_DURATION;
+    protected TimeInterpolator animation = DEFAULT_ANIMATION;
+    protected OnTargetStateChangedListener listener = null;
 
     protected abstract T self();
 
     protected abstract S build();
 
-    Activity getContext() {
+    protected Activity getContext() {
         return contextWeakReference.get();
     }
 
-    AbstractTargetBuilder(@NonNull Activity context) {
+    public AbstractTargetBuilder(@NonNull Activity context) {
         contextWeakReference = new WeakReference<>(context);
     }
 

--- a/spotlight/src/main/java/com/takusemba/spotlight/target/Target.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/target/Target.java
@@ -22,7 +22,7 @@ public abstract class Target {
     private TimeInterpolator animation;
     private OnTargetStateChangedListener listener;
 
-    Target(Shape shape, PointF point, View overlay, long duration, TimeInterpolator animation, OnTargetStateChangedListener listener) {
+    public Target(Shape shape, PointF point, View overlay, long duration, TimeInterpolator animation, OnTargetStateChangedListener listener) {
         this.shape = shape;
         this.point = point;
         this.overlay = overlay;


### PR DESCRIPTION
Thanks for creating this really usefully library. One of the only ones out there that got the public API including Shape support right! 

Just one minor nitpick. You have this concept of an `Target` that can be extended with a custom view (CustomTarget). 

But to implement something similar to `SimpleTarget`, with a custom view I would like to write my own Target by extending the base `Target` class but that is currently not possible because of the private constructor. You didn't mark the `Target` class explicitly as final so I think that this is how it was intended to be used. The same stuff 
