### PR TITLE
Fix NPE on turnDown

### DIFF
--- a/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
@@ -94,6 +94,10 @@ class SpotlightView extends FrameLayout {
     }
 
     void turnDown(AbstractAnimatorListener listener) {
+        if (currentTarget == null) {
+            return;
+        }
+
         animator = ValueAnimator.ofFloat(1f, 0f);
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override


### PR DESCRIPTION
@TakuSemba Pull request fixes the following exception:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'android.animation.TimeInterpolator ckp.e()' on a null object reference
       at com.takusemba.spotlight.SpotlightView.turnDown(SpotlightView.java:105)
       at com.takusemba.spotlight.Spotlight.finishTarget(Spotlight.java:225)
       at com.takusemba.spotlight.Spotlight.closeCurrentTarget(Spotlight.java:150)...
```