### PR TITLE
title and description by string id

### DIFF
--- a/spotlight/src/main/java/com/takusemba/spotlight/target/SimpleTarget.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/target/SimpleTarget.java
@@ -42,12 +42,22 @@ public class SimpleTarget extends Target {
       this.title = title;
       return this;
     }
+    
+    public Builder setTitle(int title) {
+      this.title = getContext().getString(title);
+      return this;
+    }
 
     public Builder setDescription(CharSequence description) {
       this.description = description;
       return this;
     }
 
+    public Builder setDescription(int description) {
+      this.description = getContext().getString(description);
+      return this;
+    }
+    
     public Builder setOverlayPoint(PointF overlayPoint) {
       this.overlayPoint = overlayPoint;
       return this;


### PR DESCRIPTION
Add hability to set title and description with String resource id
Examples:
.setTitle(R.string.spotligt_target_title);
.setDescription(R.string.spotligt_target_description);



With this, i dont need to use this:

 SimpleTarget targetHints = new SimpleTarget.Builder(this)
                .setTitle(getString(R.string.spotligt_target_title))
                .setDescription(getString(R.string.spotligt_target_description))