### PR TITLE
Enable click through target

### DIFF
--- a/spotlight/src/main/java/com/takusemba/spotlight/OnSpotlightListener.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/OnSpotlightListener.java
@@ -11,4 +11,6 @@ interface OnSpotlightListener {
    * called when SpotlightView is clicked
    */
   void onSpotlightViewClicked();
+
+  boolean canClickThroughTarget();
 }

--- a/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.java
@@ -33,6 +33,7 @@ public class Spotlight {
   private OnSpotlightStateChangedListener spotlightListener;
   private int overlayColor = DEFAULT_OVERLAY_COLOR;
   private boolean isClosedOnTouchedOutside = true;
+  private boolean canClickThroughTarget = true;
 
   private Spotlight(Activity activity) {
     contextWeakReference = new WeakReference<>(activity);
@@ -131,6 +132,17 @@ public class Spotlight {
   }
 
   /**
+   * Sets if touch events pass through Target
+   *
+   * @param canClickThroughTarget can touch events pass through target
+   * @return This Spotlight
+   */
+  public Spotlight setClickThroughTarget(boolean canClickThroughTarget) {
+    this.canClickThroughTarget = canClickThroughTarget;
+    return this;
+  }
+
+  /**
    * Shows {@link SpotlightView}
    */
   public void start() {
@@ -165,6 +177,10 @@ public class Spotlight {
             if (isClosedOnTouchedOutside) {
               finishTarget();
             }
+          }
+
+          @Override public boolean canClickThroughTarget() {
+            return canClickThroughTarget;
           }
         });
     spotlightViewWeakReference = new WeakReference<>(spotlightView);

--- a/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
@@ -44,6 +44,7 @@ class SpotlightView extends FrameLayout {
       @Override
       public boolean onTouch(View view, MotionEvent motionEvent) {
         if (listener.canClickThroughTarget() &&
+            currentTarget != null &&
             currentTarget.contains(motionEvent.getX(), motionEvent.getY())) {
 
           return false;

--- a/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.java
@@ -9,6 +9,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -39,11 +40,23 @@ class SpotlightView extends FrameLayout {
     spotPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
     setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.MATCH_PARENT));
-    setOnClickListener(new OnClickListener() {
-      @Override public void onClick(View v) {
-        if (animator != null && !animator.isRunning() && (float) animator.getAnimatedValue() > 0) {
-          if (listener != null) listener.onSpotlightViewClicked();
+    setOnTouchListener(new FrameLayout.OnTouchListener() {
+      @Override
+      public boolean onTouch(View view, MotionEvent motionEvent) {
+        if (listener.canClickThroughTarget() &&
+            currentTarget.contains(motionEvent.getX(), motionEvent.getY())) {
+
+          return false;
         }
+
+        if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+          view.performClick();
+          if (animator != null && !animator.isRunning() && (float) animator.getAnimatedValue() > 0) {
+            if (listener != null) listener.onSpotlightViewClicked();
+          }
+        }
+
+        return true;
       }
     });
   }

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.java
@@ -19,4 +19,9 @@ public class Circle implements Shape {
   @Override public void draw(Canvas canvas, PointF point, float value, Paint paint) {
     canvas.drawCircle(point.x, point.y, value * radius, paint);
   }
+
+  @Override public boolean contains(PointF point, float x, float y) {
+    double dist = Math.hypot(point.x - x, point.y - y);
+    return dist < radius;
+  }
 }

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.java
@@ -31,5 +31,15 @@ public class RoundedRectangle implements Shape {
     RectF rect = new RectF(left, top, right, bottom);
     canvas.drawRoundRect(rect, radius, radius, paint);
   }
+
+  @Override public boolean contains(PointF point, float x, float y) {
+    float halfWidth = width / 2;
+    float halfHeight = height / 2;
+    float left = point.x - halfWidth;
+    float top = point.y - halfHeight;
+    float right = point.x + halfWidth;
+    float bottom = point.y + halfHeight;
+    return (x > left && x < right) && (y > top && y < bottom);
+  }
 }
 

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.java
@@ -17,4 +17,12 @@ public interface Shape {
    * @param value the animated value from 0 to 1
    */
   void draw(Canvas canvas, PointF point, float value, Paint paint);
+
+
+  /**
+   * check if point is contained within the Shape
+   *
+   * @param point center of the Shape
+   */
+  boolean contains(PointF point, float x, float y);
 }

--- a/spotlight/src/main/java/com/takusemba/spotlight/target/Target.java
+++ b/spotlight/src/main/java/com/takusemba/spotlight/target/Target.java
@@ -84,4 +84,13 @@ public abstract class Target {
   public OnTargetStateChangedListener getListener() {
     return listener;
   }
+
+ /**
+   * checks if point is contained within this Target
+   *
+   * @return target contains point
+   */
+  public boolean contains(float x, float y) {
+    return shape.contains(point, x, y);
+  }
 }


### PR DESCRIPTION
These changes allow you to enable the ability to pass touch events through the target part of the spotlight while maintaining the close on touch outside functionality on the overlay.