### PR TITLE
Enable click through target in Kotlin

### DIFF
--- a/app/src/main/java/com/takusemba/spotlightsample/MainActivity.kt
+++ b/app/src/main/java/com/takusemba/spotlightsample/MainActivity.kt
@@ -56,6 +56,7 @@ class MainActivity : AppCompatActivity() {
           .setAnchor(findViewById<View>(R.id.two))
           .setShape(Circle(150f))
           .setOverlay(second)
+          .isClickable(false)
           .setOnTargetListener(object : OnTargetListener {
             override fun onStarted() {
               currentToast?.cancel()
@@ -131,6 +132,24 @@ class MainActivity : AppCompatActivity() {
       first.findViewById<View>(R.id.close_spotlight).setOnClickListener(closeSpotlight)
       second.findViewById<View>(R.id.close_spotlight).setOnClickListener(closeSpotlight)
       third.findViewById<View>(R.id.close_spotlight).setOnClickListener(closeSpotlight)
+    }
+
+    findViewById<View>(R.id.one).setOnClickListener {
+      currentToast?.cancel()
+      currentToast = makeText(this@MainActivity, "number one click", LENGTH_SHORT)
+      currentToast?.show()
+    }
+
+    findViewById<View>(R.id.two).setOnClickListener {
+      currentToast?.cancel()
+      currentToast = makeText(this@MainActivity, "number two click", LENGTH_SHORT)
+      currentToast?.show()
+    }
+
+    findViewById<View>(R.id.three).setOnClickListener {
+      currentToast?.cancel()
+      currentToast = makeText(this@MainActivity, "number three click", LENGTH_SHORT)
+      currentToast?.show()
     }
   }
 }

--- a/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/SpotlightView.kt
@@ -48,6 +48,9 @@ internal class SpotlightView @JvmOverloads constructor(
   init {
     setWillNotDraw(false)
     setLayerType(View.LAYER_TYPE_HARDWARE, null)
+    setOnTouchListener { _, event ->
+      !(target != null && target!!.isClickable && target!!.contains(event.x, event.y))
+    }
   }
 
   override fun onDraw(canvas: Canvas) {

--- a/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
@@ -15,8 +15,18 @@ class Target(
     val shape: Shape,
     val effect: Effect,
     val overlay: View?,
-    val listener: OnTargetListener?
+    val listener: OnTargetListener?,
+    val isClickable: Boolean
 ) {
+
+  /**
+   * Check if point is contained within the Shape
+   *
+   * @param anchor center of the Shape
+   */
+  fun contains(x: Float, y: Float): Boolean {
+    return shape.contains(anchor, x, y)
+  }
 
   /**
    * [Builder] to build a [Target].
@@ -29,6 +39,7 @@ class Target(
     private var effect: Effect = DEFAULT_EFFECT
     private var overlay: View? = null
     private var listener: OnTargetListener? = null
+    private var isClickable: Boolean = DEFAULT_IS_CLICKABLE
 
     /**
      * Sets a pointer to start a [Target].
@@ -83,12 +94,20 @@ class Target(
       this.listener = listener
     }
 
+    /**
+     * Sets [isClickable] to enable or disable the click through [Target].
+     */
+    fun isClickable(isClickable: Boolean): Builder = apply {
+      this.isClickable = isClickable
+    }
+
     fun build() = Target(
         anchor = anchor,
         shape = shape,
         effect = effect,
         overlay = overlay,
-        listener = listener
+        listener = listener,
+        isClickable = isClickable
     )
 
     companion object {
@@ -98,6 +117,8 @@ class Target(
       private val DEFAULT_SHAPE = Circle(100f)
 
       private val DEFAULT_EFFECT = EmptyEffect()
+
+      private const val DEFAULT_IS_CLICKABLE = true
     }
   }
 }

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
@@ -6,6 +6,7 @@ import android.graphics.Paint
 import android.graphics.PointF
 import android.view.animation.DecelerateInterpolator
 import java.util.concurrent.TimeUnit
+import kotlin.math.hypot
 
 /**
  * [Shape] of Circle with customizable radius.
@@ -18,6 +19,11 @@ class Circle(
 
   override fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint) {
     canvas.drawCircle(point.x, point.y, value * radius, paint)
+  }
+
+  override fun contains(point: PointF, x: Float, y: Float): Boolean {
+    val dist = hypot((point.x - x).toDouble(), (point.y - y).toDouble())
+    return dist < radius
   }
 
   companion object {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
@@ -30,6 +30,16 @@ class RoundedRectangle(
     canvas.drawRoundRect(rect, radius, radius, paint)
   }
 
+  override fun contains(point: PointF, x: Float, y: Float): Boolean {
+    val halfWidth = width / 2
+    val halfHeight = height / 2
+    val left = point.x - halfWidth
+    val top = point.y - halfHeight
+    val right = point.x + halfWidth
+    val bottom = point.y + halfHeight
+    return x > left && x < right && y > top && y < bottom
+  }
+
   companion object {
 
     val DEFAULT_DURATION = TimeUnit.MILLISECONDS.toMillis(500)

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
@@ -28,4 +28,11 @@ interface Shape {
    * @param value the animated value from 0 to 1.
    */
   fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint)
+
+  /**
+   * Check if point is contained within the Shape
+   *
+   * @param point center of the Shape
+   */
+  fun contains(point: PointF, x: Float, y: Float): Boolean
 }


### PR DESCRIPTION
Based on @shurwit pull request:
These changes allow you to enable the ability to pass touch events through the target part of the spotlight while maintaining the close on touch outside functionality on the overlay.