### PR TITLE
Feature: finish spotlight on touch outside of current target

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ If you want to show Spotlight immediately, you have to wait until views are laid
 view.doOnPreDraw { Spotlight.Builder(this)...start() }
 ```
 
+If you want to enable (disabled by default) finishing Spotlight on touch outside of current target:
+
+```kt
+val spotlight = Spotlight.Builder(this)
+    ...
+    .setFinishOnTouchOutsideOfCurrentTarget(true)
+    ...
+    .build()    
+```
+
 <br/>
 <br/>
 
@@ -107,6 +117,10 @@ class CustomShape(
 
   override fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint) {
     // draw your shape here.
+  }
+  
+  override fun contains(anchor: PointF, point: PointF): Boolean {
+    // check if point is inside of shape here.
   }
 }
 ```

--- a/spotlight/src/main/java/com/takusemba/spotlight/OnTouchOutsideOfCurrentTargetListener.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/OnTouchOutsideOfCurrentTargetListener.kt
@@ -1,0 +1,9 @@
+package com.takusemba.spotlight
+
+/**
+ * Listener to notify when user touches spotlight outside of current Target.
+ */
+interface OnTouchOutsideOfCurrentTargetListener {
+
+  fun onEvent()
+}

--- a/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
@@ -146,6 +146,8 @@ class Spotlight private constructor(
     @ColorInt private var backgroundColor: Int = DEFAULT_OVERLAY_COLOR
     private var container: ViewGroup? = null
     private var listener: OnSpotlightListener? = null
+    // Finish on touch outside of current target feature is disabled by default
+    private var finishOnTouchOutsideOfCurrentTarget: Boolean = false
 
     /**
      * Sets [Target]s to show on [Spotlight].
@@ -203,6 +205,16 @@ class Spotlight private constructor(
      */
     fun setOnSpotlightListener(listener: OnSpotlightListener): Builder = apply {
       this.listener = listener
+    }
+
+    /**
+     * Sets [finishOnTouchOutsideOfCurrentTarget] flag
+     * to enable/disable (true/false) finishing on touch outside feature.
+     */
+    fun setFinishOnTouchOutsideOfCurrentTarget(
+        finishOnTouchOutsideOfCurrentTarget: Boolean
+    ): Builder = apply {
+      this.finishOnTouchOutsideOfCurrentTarget = finishOnTouchOutsideOfCurrentTarget
     }
 
     fun build(): Spotlight {

--- a/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
@@ -146,6 +146,7 @@ class Spotlight private constructor(
     @ColorInt private var backgroundColor: Int = DEFAULT_OVERLAY_COLOR
     private var container: ViewGroup? = null
     private var listener: OnSpotlightListener? = null
+
     // Finish on touch outside of current target feature is disabled by default
     private var finishOnTouchOutsideOfCurrentTarget: Boolean = false
 
@@ -218,19 +219,25 @@ class Spotlight private constructor(
     }
 
     fun build(): Spotlight {
-
-      val spotlight = SpotlightView(activity, null, 0, backgroundColor)
+      val spotlightView = SpotlightView(activity, null, 0, backgroundColor)
       val targets = requireNotNull(targets) { "targets should not be null. " }
       val container = container ?: activity.window.decorView as ViewGroup
-
       return Spotlight(
-          spotlightView = spotlight,
+          spotlightView = spotlightView,
           targets = targets,
           duration = duration,
           interpolator = interpolator,
           container = container,
           spotlightListener = listener
-      )
+      ).apply {
+        if (this@Builder.finishOnTouchOutsideOfCurrentTarget) {
+          spotlightView.setOnTouchOutsideOfCurrentTargetListener(
+              object : OnTouchOutsideOfCurrentTargetListener {
+                override fun onEvent() = finishSpotlight()
+              }
+          )
+        }
+      }
     }
 
     companion object {

--- a/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Spotlight.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
  * unless you create a new [Spotlight] to start again.
  */
 class Spotlight private constructor(
-    private val spotlight: SpotlightView,
+    private val spotlightView: SpotlightView,
     private val targets: Array<Target>,
     private val duration: Long,
     private val interpolator: TimeInterpolator,
@@ -32,7 +32,7 @@ class Spotlight private constructor(
   private var currentIndex = NO_POSITION
 
   init {
-    container.addView(spotlight, MATCH_PARENT, MATCH_PARENT)
+    container.addView(spotlightView, MATCH_PARENT, MATCH_PARENT)
   }
 
   /**
@@ -77,7 +77,7 @@ class Spotlight private constructor(
    * Starts Spotlight.
    */
   private fun startSpotlight() {
-    spotlight.startSpotlight(duration, interpolator, object : AnimatorListenerAdapter() {
+    spotlightView.startSpotlight(duration, interpolator, object : AnimatorListenerAdapter() {
       override fun onAnimationStart(animation: Animator) {
         spotlightListener?.onStarted()
       }
@@ -95,10 +95,10 @@ class Spotlight private constructor(
     if (currentIndex == NO_POSITION) {
       val target = targets[index]
       currentIndex = index
-      spotlight.startTarget(target)
+      spotlightView.startTarget(target)
       target.listener?.onStarted()
     } else {
-      spotlight.finishTarget(object : AnimatorListenerAdapter() {
+      spotlightView.finishTarget(object : AnimatorListenerAdapter() {
         override fun onAnimationEnd(animation: Animator) {
           val previousIndex = currentIndex
           val previousTarget = targets[previousIndex]
@@ -106,7 +106,7 @@ class Spotlight private constructor(
           if (index < targets.size) {
             val target = targets[index]
             currentIndex = index
-            spotlight.startTarget(target)
+            spotlightView.startTarget(target)
             target.listener?.onStarted()
           } else {
             finishSpotlight()
@@ -120,10 +120,10 @@ class Spotlight private constructor(
    * Closes Spotlight.
    */
   private fun finishSpotlight() {
-    spotlight.finishSpotlight(duration, interpolator, object : AnimatorListenerAdapter() {
+    spotlightView.finishSpotlight(duration, interpolator, object : AnimatorListenerAdapter() {
       override fun onAnimationEnd(animation: Animator) {
-        spotlight.cleanup()
-        container.removeView(spotlight)
+        spotlightView.cleanup()
+        container.removeView(spotlightView)
         spotlightListener?.onEnded()
       }
     })
@@ -224,7 +224,7 @@ class Spotlight private constructor(
       val container = container ?: activity.window.decorView as ViewGroup
 
       return Spotlight(
-          spotlight = spotlight,
+          spotlightView = spotlight,
           targets = targets,
           duration = duration,
           interpolator = interpolator,

--- a/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
@@ -5,10 +5,7 @@ import android.view.View
 import com.takusemba.spotlight.effet.Effect
 import com.takusemba.spotlight.effet.EmptyEffect
 import com.takusemba.spotlight.shape.Circle
-import com.takusemba.spotlight.shape.RoundedRectangle
 import com.takusemba.spotlight.shape.Shape
-import kotlin.math.abs
-import kotlin.math.pow
 
 /**
  * Target represents the spot that Spotlight will cast.
@@ -24,30 +21,10 @@ class Target(
   /**
    * Checks if point on edge or inside of the Shape.
    *
-   * @param point point to check against contains
-   * @return true if contains, false - otherwise
+   * @param point point to check against contains.
+   * @return true if contains, false - otherwise.
    */
-  fun contains(point: PointF): Boolean {
-    val xNorm = point.x - anchor.x
-    val yNorm = point.y - anchor.y
-    return when (shape) {
-      is Circle -> {
-        (xNorm * xNorm + yNorm * yNorm) <= shape.radius * shape.radius
-      }
-      is RoundedRectangle -> {
-        // Ellipsis function is used to check if point is in rounded rectangle
-        // Ellipsis doesn't guarantee ideal precision. Check https://en.wikipedia.org/wiki/Squircle
-        val widthHalf = shape.width / 2
-        val heightHalf = shape.height / 2
-        // r = [0; widthHalf], where 0 - rectangle, widthHalf - "smooth" ellipse
-        val r = shape.radius.coerceIn(minimumValue = 0f, maximumValue = widthHalf)
-        // n = [2; inf], where - "smooth" ellipse, inf - rectangle
-        val n = shape.width / r
-        abs((xNorm / widthHalf)).pow(n) + abs((yNorm / heightHalf)).pow(n) <= 1
-      }
-      else -> throw IllegalStateException("Unknown shape: ${shape::class.qualifiedName}")
-    }
-  }
+  fun contains(point: PointF): Boolean = shape.contains(anchor, point)
 
   /**
    * [Builder] to build a [Target].

--- a/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
@@ -8,6 +8,7 @@ import com.takusemba.spotlight.shape.Circle
 import com.takusemba.spotlight.shape.RoundedRectangle
 import com.takusemba.spotlight.shape.Shape
 import kotlin.math.abs
+import kotlin.math.pow
 
 /**
  * Target represents the spot that Spotlight will cast.
@@ -33,10 +34,16 @@ class Target(
       is Circle -> {
         (xNorm * xNorm + yNorm * yNorm) <= shape.radius * shape.radius
       }
-      // Rounded corners are not took into account
-      // TODO calculate more precisely
       is RoundedRectangle -> {
-        (abs(xNorm) <= shape.width / 2) && (abs(yNorm) <= shape.height / 2)
+        // Ellipsis function is used to check if point is in rounded rectangle
+        // Ellipsis doesn't guarantee ideal precision. Check https://en.wikipedia.org/wiki/Squircle
+        val widthHalf = shape.width / 2
+        val heightHalf = shape.height / 2
+        // r = [0; widthHalf], where 0 - rectangle, widthHalf - "smooth" ellipse
+        val r = shape.radius.coerceIn(minimumValue = 0f, maximumValue = widthHalf)
+        // n = [2; inf], where - "smooth" ellipse, inf - rectangle
+        val n = shape.width / r
+        abs((xNorm / widthHalf)).pow(n) + abs((yNorm / heightHalf)).pow(n) <= 1
       }
       else -> throw IllegalStateException("Unknown shape: ${shape::class.qualifiedName}")
     }

--- a/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/Target.kt
@@ -5,7 +5,9 @@ import android.view.View
 import com.takusemba.spotlight.effet.Effect
 import com.takusemba.spotlight.effet.EmptyEffect
 import com.takusemba.spotlight.shape.Circle
+import com.takusemba.spotlight.shape.RoundedRectangle
 import com.takusemba.spotlight.shape.Shape
+import kotlin.math.abs
 
 /**
  * Target represents the spot that Spotlight will cast.
@@ -17,6 +19,28 @@ class Target(
     val overlay: View?,
     val listener: OnTargetListener?
 ) {
+
+  /**
+   * Checks if point on edge or inside of the Shape.
+   *
+   * @param point point to check against contains
+   * @return true if contains, false - otherwise
+   */
+  fun contains(point: PointF): Boolean {
+    val xNorm = point.x - anchor.x
+    val yNorm = point.y - anchor.y
+    return when (shape) {
+      is Circle -> {
+        (xNorm * xNorm + yNorm * yNorm) <= shape.radius * shape.radius
+      }
+      // Rounded corners are not took into account
+      // TODO calculate more precisely
+      is RoundedRectangle -> {
+        (abs(xNorm) <= shape.width / 2) && (abs(yNorm) <= shape.height / 2)
+      }
+      else -> throw IllegalStateException("Unknown shape: ${shape::class.qualifiedName}")
+    }
+  }
 
   /**
    * [Builder] to build a [Target].

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
@@ -11,13 +11,19 @@ import java.util.concurrent.TimeUnit
  * [Shape] of Circle with customizable radius.
  */
 class Circle @JvmOverloads constructor(
-    val radius: Float,
+    private val radius: Float,
     override val duration: Long = DEFAULT_DURATION,
     override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR
 ) : Shape {
 
   override fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint) {
     canvas.drawCircle(point.x, point.y, value * radius, paint)
+  }
+
+  override fun contains(anchor: PointF, point: PointF): Boolean {
+    val xNorm = point.x - anchor.x
+    val yNorm = point.y - anchor.y
+    return (xNorm * xNorm + yNorm * yNorm) <= radius * radius
   }
 
   companion object {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Circle.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
  * [Shape] of Circle with customizable radius.
  */
 class Circle @JvmOverloads constructor(
-    private val radius: Float,
+    val radius: Float,
     override val duration: Long = DEFAULT_DURATION,
     override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR
 ) : Shape {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
@@ -12,9 +12,9 @@ import java.util.concurrent.TimeUnit
  * [Shape] of RoundedRectangle with customizable height, width, and radius.
  */
 class RoundedRectangle @JvmOverloads constructor(
-    private val height: Float,
-    private val width: Float,
-    private val radius: Float,
+    val height: Float,
+    val width: Float,
+    val radius: Float,
     override val duration: Long = DEFAULT_DURATION,
     override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR
 ) : Shape {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
@@ -7,14 +7,16 @@ import android.graphics.PointF
 import android.graphics.RectF
 import android.view.animation.DecelerateInterpolator
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import kotlin.math.pow
 
 /**
  * [Shape] of RoundedRectangle with customizable height, width, and radius.
  */
 class RoundedRectangle @JvmOverloads constructor(
-    val height: Float,
-    val width: Float,
-    val radius: Float,
+    private val height: Float,
+    private val width: Float,
+    private val radius: Float,
     override val duration: Long = DEFAULT_DURATION,
     override val interpolator: TimeInterpolator = DEFAULT_INTERPOLATOR
 ) : Shape {
@@ -28,6 +30,25 @@ class RoundedRectangle @JvmOverloads constructor(
     val bottom = point.y + halfHeight
     val rect = RectF(left, top, right, bottom)
     canvas.drawRoundRect(rect, radius, radius, paint)
+  }
+
+  /**
+   * Ellipsis function is used to check if point is in rounded rectangle.
+   * Ellipsis doesn't guarantee ideal precision.
+   * Check https://en.wikipedia.org/wiki/Squircle
+   *
+   * Calculated values:
+   * - r = [0; widthHalf], where 0 - rectangle, widthHalf - "smooth" ellipse
+   * - n = [2; inf], where - "smooth" ellipse, inf - rectangle
+   */
+  override fun contains(anchor: PointF, point: PointF): Boolean {
+    val xNorm = point.x - anchor.x
+    val yNorm = point.y - anchor.y
+    val widthHalf = width / 2
+    val heightHalf = height / 2
+    val r = radius.coerceIn(minimumValue = 0f, maximumValue = widthHalf)
+    val n = width / r
+    return abs((xNorm / widthHalf)).pow(n) + abs((yNorm / heightHalf)).pow(n) <= 1
   }
 
   companion object {

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/RoundedRectangle.kt
@@ -39,7 +39,7 @@ class RoundedRectangle @JvmOverloads constructor(
    *
    * Calculated values:
    * - r = [0; widthHalf], where 0 - rectangle, widthHalf - "smooth" ellipse
-   * - n = [2; inf], where - "smooth" ellipse, inf - rectangle
+   * - n = [2; inf], where 2 - "smooth" ellipse, inf - rectangle
    */
   override fun contains(anchor: PointF, point: PointF): Boolean {
     val xNorm = point.x - anchor.x
@@ -47,7 +47,7 @@ class RoundedRectangle @JvmOverloads constructor(
     val widthHalf = width / 2
     val heightHalf = height / 2
     val r = radius.coerceIn(minimumValue = 0f, maximumValue = widthHalf)
-    val n = width / r
+    val n = maxOf(width, height) / r
     return abs((xNorm / widthHalf)).pow(n) + abs((yNorm / heightHalf)).pow(n) <= 1
   }
 

--- a/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
+++ b/spotlight/src/main/java/com/takusemba/spotlight/shape/Shape.kt
@@ -28,4 +28,13 @@ interface Shape {
    * @param value the animated value from 0 to 1.
    */
   fun draw(canvas: Canvas, point: PointF, value: Float, paint: Paint)
+
+  /**
+   * Checks if point on edge or inside of the Shape.
+   *
+   * @param anchor center of Shape.
+   * @param point point to check against contains.
+   * @return true if contains, false - otherwise.
+   */
+  fun contains(anchor: PointF, point: PointF): Boolean
 }


### PR DESCRIPTION
# Problem
I've seen issue https://github.com/TakuSemba/Spotlight/issues/123 (from @aryandii) and decided to help you make Spotlight more functional ✨

# Solution
So I added a new flag to make it possible to finish spotlight on touch outside of current target. Let's see how it looks like:
- [Circle shape showcase (gif)](https://drive.google.com/file/d/1kgAHw2jpyyKffDr7zxU1-u14DC_1vuAL/view?usp=sharing)
- [Round rectangle shape showcase (gif)](https://drive.google.com/file/d/19yJsMDOLAarZ_laYikSD9XiYm4A4e6ph/view?usp=sharing)

There is a listener to catch on touch outside of current target event. Finishing on touch outside is the only one usage of listener. If you want to add new Shape just create a child class and implement contains function. It can be quite complex if your shape is not primitive. So it can be not perfectly precise (and there is nothing horrible, IMHO). Round rectangle is an example of complex shape:
- [Round rectangle contains calculation imprecision (gif)](https://drive.google.com/file/d/1yX_-S1RwZupTzZupA7ok4L-1pFLiSNbh/view?usp=sharing)

@TakuSemba , thanks a lot for your work. I hope this feature will improve your project and engage new developers 🤝